### PR TITLE
Fix JSON escape formatting in telnet output

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -192,8 +192,9 @@ String escapeJsonString(const String& input) {
       case '\t': result += "\\t"; break;
       default:
         if (c < 0x20) {
-          result += "\\u";
-          result += String(c, HEX);
+          char buf[7];
+          snprintf(buf, sizeof(buf), "\\u%04X", static_cast<unsigned char>(c));
+          result += buf;
         } else {
           result += c;
         }


### PR DESCRIPTION
## Summary
- pad \u escape sequences to 4 digits when encoding telnet logs for JSON

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68973e3263bc832895e9d877405d3e5f